### PR TITLE
Fix data race in h.samplingRate

### DIFF
--- a/avoNetworkCallsHandler.go
+++ b/avoNetworkCallsHandler.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math/rand"
 	"net/http"
@@ -113,7 +113,7 @@ func (h *AvoNetworkCallsHandler) callInspectorWithBatchBody(events []interface{}
 	}
 
 	// Read response body
-	responseBody, err := ioutil.ReadAll(res.Body)
+	responseBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return fmt.Errorf("failed to read response body: %v", err)
 	}

--- a/avoNetworkCallsHandler.go
+++ b/avoNetworkCallsHandler.go
@@ -41,26 +41,28 @@ type EventSchemaBody struct {
 }
 
 type AvoNetworkCallsHandler struct {
-	apiKey       string
-	envName      string
-	appName      string
-	appVersion   string
-	libVersion   string
-	samplingRate float64
-	shouldLog    bool
+	apiKey           string
+	envName          string
+	appName          string
+	appVersion       string
+	libVersion       string
+	samplingRate     float64
+	shouldLog        bool
+	trackingEndpoint string
 }
 
 const trackingEndpoint = "https://api.avo.app/inspector/v1/track"
 
 func newAvoNetworkCallsHandler(apiKey, envName, appName, appVersion, libVersion string, shouldLog bool) *AvoNetworkCallsHandler {
 	return &AvoNetworkCallsHandler{
-		apiKey:       apiKey,
-		envName:      envName,
-		appName:      appName,
-		appVersion:   appVersion,
-		libVersion:   libVersion,
-		samplingRate: 1.0,
-		shouldLog:    shouldLog,
+		apiKey:           apiKey,
+		envName:          envName,
+		appName:          appName,
+		appVersion:       appVersion,
+		libVersion:       libVersion,
+		samplingRate:     1.0,
+		shouldLog:        shouldLog,
+		trackingEndpoint: trackingEndpoint,
 	}
 }
 
@@ -94,7 +96,7 @@ func (h *AvoNetworkCallsHandler) callInspectorWithBatchBody(events []interface{}
 	}
 
 	client := http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequest(http.MethodPost, trackingEndpoint, bytes.NewReader(eventsPayload))
+	req, err := http.NewRequest(http.MethodPost, h.trackingEndpoint, bytes.NewReader(eventsPayload))
 	if err != nil {
 		return fmt.Errorf("could not create request: %v", err)
 	}

--- a/avoNetworkCallsHandler_test.go
+++ b/avoNetworkCallsHandler_test.go
@@ -1,9 +1,97 @@
 package avoinspector
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 )
+
+func TestAvoNetworkCallsHandler_callInspectorWithBatchBody(t *testing.T) {
+	type testCase struct {
+		serverCallback func() *httptest.Server
+		event          any
+		expectedError  string
+	}
+
+	testCases := map[string]testCase{
+		"should log": {
+			serverCallback: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte(`{"samplingRate": 0.001}`))
+				}))
+			},
+			event: map[string]any{
+				"number_prop":  1,
+				"string_prop":  "test",
+				"boolean_prop": true,
+			},
+		},
+		"detect unmarshable event": {
+			serverCallback: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+			},
+			event:         func() {},
+			expectedError: "could not marshal events",
+		},
+		"detect invalid response status code": {
+			serverCallback: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusBadRequest)
+				}))
+			},
+			event: map[string]any{
+				"number_prop":  1,
+				"string_prop":  "test",
+				"boolean_prop": true,
+			},
+			expectedError: "request returned non-200 status code",
+		},
+		"detect invalid response body": {
+			serverCallback: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+				}))
+			},
+			event: map[string]any{
+				"number_prop":  1,
+				"string_prop":  "test",
+				"boolean_prop": true,
+			},
+			expectedError: "failed to parse response body",
+		},
+	}
+
+	for testName, tc := range testCases {
+		t.Run(testName, func(t *testing.T) {
+			// Setup a test server to mock the communication with Avo Inspector
+			srv := tc.serverCallback()
+			defer srv.Close()
+
+			// Create an instance of AvoNetworkCallsHandler
+			handler := &AvoNetworkCallsHandler{
+				apiKey:           "test-api-key",
+				envName:          "test",
+				appName:          "test-app",
+				appVersion:       "1.0.0",
+				libVersion:       "1.0.0",
+				samplingRate:     1.0,
+				shouldLog:        false,
+				trackingEndpoint: srv.URL,
+			}
+
+			// Verify the result
+			err := handler.callInspectorWithBatchBody([]any{tc.event})
+			if err == nil && tc.expectedError != "" {
+				t.Errorf("expected error '%s' but got none", tc.expectedError)
+			} else if err != nil && !strings.Contains(err.Error(), tc.expectedError) {
+				t.Errorf("unexpected error, got: %s and expected '%s'", err, tc.expectedError)
+			}
+		})
+	}
+}
 
 func TestAvoNetworkCallsHandler_bodyForSessionStartedCall(t *testing.T) {
 	// Create an instance of AvoNetworkCallsHandler


### PR DESCRIPTION
closes https://github.com/avohq/go-avo-inspector/issues/10

The Avo inspector handler can't be used concurrently given that `h.samplingRate` allows for race conditions where different go-routines can read it and/or write to it. 

It's being read [here](https://github.com/avohq/go-avo-inspector/blob/adecaca/avoNetworkCallsHandler.go#L77) and written [here](https://github.com/avohq/go-avo-inspector/blob/adecaca/avoNetworkCallsHandler.go#L131).

In `avoNetworkCallsHandler_test.go` [we're adding coverage](https://github.com/avohq/go-avo-inspector/commit/729b3151257d0676bef02020fd1a47e70f3ea646) to assert that no race condition happens when the inspector is used concurrently by different go-routines.